### PR TITLE
Install CodeSee Maps on this repo.

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,0 +1,62 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+name: CodeSee Map
+
+jobs:
+  test_map_action:
+    runs-on: ubuntu-latest
+    name: Run map action on action code
+    steps:
+      - name: checkout
+        id: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # codesee-detect-languages has an output with id languages.
+      - name: Detect Languages
+        id: detect-languages
+        uses: Codesee-io/codesee-detect-languages-action@latest
+
+      - name: Configure JDK 16
+        uses: actions/setup-java@v2
+        if: ${{ fromJSON(steps.detect-languages.outputs.languages).java }}
+        with:
+          java-version: '16'
+          distribution: 'zulu'
+
+      # CodeSee Maps Go support uses a static binary so there's no setup step required.
+
+      - name: Configure Node.js 14
+        uses: actions/setup-node@v2
+        if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript }}
+        with:
+          node-version: '14'
+
+      - name: Configure Python 3.x
+        uses: actions/setup-python@v2
+        if: ${{ fromJSON(steps.detect-languages.outputs.languages).python }}
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Configure Ruby '3.x'
+        uses: ruby/setup-ruby@v1
+        if: ${{ fromJSON(steps.detect-languages.outputs.languages).ruby }}
+        with:
+          ruby-version: '3.0'
+
+      # CodeSee Maps Rust support uses a static binary so there's no setup step required.
+
+      - name: run
+        id: run
+        uses: Codesee-io/codesee-map-action@latest
+        with:
+          api_token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
+          github_ref: ${{ github.ref }}
+          support_typescript: true


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Hi @ojeytonwilliams,

While investigating why the CodeSee Map "insights" feature wasn't generating,
I discovered that the CodeSee Map github action has vanished from this repo.

This GitHub Action is how CodeSee generates maps and insights.

During the normal use of CodeSee Maps, the file in this PR will be generated for you when you create a new map on a repository. Here's an example of just such a PR: https://github.com/Codesee-io/oss-port/pull/37

That process will also present you with an API Token for you to add to your github repo secrets.

If you do not have that secret (`CODESEE_ARCH_DIAG_API_TOKEN`) setup already, please let me know. I will reset this repo so the system will generate you a new token. 

-------

Alternatively, you can use the CodeSee Maps UI to create a map on a new repo, and everything should "just work" :) 